### PR TITLE
Bidirectional flow

### DIFF
--- a/netflow/ipfix.py
+++ b/netflow/ipfix.py
@@ -766,7 +766,7 @@ class IPFIXDataRecord:
         pack = struct.unpack(unpacker, data[0:offset])
 
         # Iterate through template again, but taking the unpacked values this time
-        for index, ((field_datatype, field_type_id), value) in enumerate(zip(discovered_fields, pack)):
+        for index, ((field_datatype, field_type_id), value, field) in enumerate(zip(discovered_fields, pack, template)):
             if type(value) is bytes:
                 # Check if value is raw bytes, so no conversion happened in struct.unpack
                 if field_datatype in ["string"]:
@@ -782,7 +782,8 @@ class IPFIXDataRecord:
                     value = int.from_bytes(value, "big")
             # If not bytes, struct.unpack already did necessary conversions (int, float...),
             # value can be used as-is.
-            self.fields.add((field_type_id, value))
+            self.fields.add((field_type_id, value, True if type(field) is TemplateFieldEnterprise and
+                                                           field.enterprise_number == 29305 else False))
 
         self._length = offset
         self.__dict__.update(self.data)
@@ -793,7 +794,7 @@ class IPFIXDataRecord:
     @property
     def data(self):
         return {
-            IPFIXFieldTypes.by_id(key)[1]: value for (key, value) in self.fields
+            IPFIXFieldTypes.by_id(key)[1] + ("_" if biflow else ""): value for (key, value, biflow) in self.fields
         }
 
     def __repr__(self):


### PR DESCRIPTION
This work adds support for RFC5103: Bidirectional Flow Export Using IP Flow Information Export (IPFIX). I needed this support for some work I am doing.

There is an open question on what the reverse fields should be called and if the current approach is the best way to handle it? Should we passing out the the field is a reverse field as opposed to simply adding a "_" onto the name.

The approach is working for me but can make changes as required.